### PR TITLE
Use reflect and add coverage of more scenarios

### DIFF
--- a/datatypes.go
+++ b/datatypes.go
@@ -1,5 +1,7 @@
 package datatypes
 
+import "reflect"
+
 // FYI these are the types when you use json.Unmarshal
 //
 // bool, for JSON booleans
@@ -9,21 +11,32 @@ package datatypes
 // map[string]interface{}, for JSON objects
 // nil for JSON null
 
+var byteSliceType = reflect.TypeOf([]byte(nil))
+
 func DataType(v interface{}) string {
 	if v == nil {
 		return "null"
 	}
 
-	switch v.(type) {
-	case int, int8, int32, int64, uint, uint8, uint32, uint64, float32, float64:
+	valueOf := reflect.ValueOf(v)
+
+	switch valueOf.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return "number"
-	case string:
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return "number"
+	case reflect.Float32, reflect.Float64:
+		return "number"
+	case reflect.String:
 		return "string"
-	case bool:
+	case reflect.Bool:
 		return "boolean"
-	case []interface{}, []string, []int, []int8, []int32, []int64, []uint, []uint8, []uint32, []uint64, []float32, []float64:
+	case reflect.Array, reflect.Slice:
+		if valueOf.Type() == byteSliceType {
+			return "string"
+		}
 		return "array"
-	case map[interface{}]interface{}, map[string]interface{}:
+	case reflect.Map, reflect.Struct:
 		return "object"
 	default:
 		return "value"

--- a/datatypes_test.go
+++ b/datatypes_test.go
@@ -3,11 +3,32 @@ package datatypes
 import "github.com/bmizerany/assert"
 import "testing"
 
-func TestDatatype(t *testing.T) {
+func TestDataTypeForArrays(t *testing.T) {
+	assert.Equal(t, "array", DataType([]bool{true, false}))
+	assert.Equal(t, "array", DataType([2]int{1, 2}))
+	assert.Equal(t, "array", DataType([]string{"hello", "world"}))
+
+	// Byte slices are base64 encoded; byte arrays are not.
+	assert.Equal(t, "string", DataType([]byte{1, 0, 1}))
+	assert.Equal(t, "string", DataType([]uint8{1, 0, 1}))
+	assert.Equal(t, "array", DataType([3]byte{1, 0, 1}))
+}
+
+type sample struct {
+	id   int
+	name string
+}
+
+func TestDataTypeForObjects(t *testing.T) {
+	assert.Equal(t, "object", DataType(sample{id: 1, name: "test"}))
+	assert.Equal(t, "object", DataType(map[string]interface{}{"hello": "world"}))
+}
+
+func TestDataTypeForPrimitives(t *testing.T) {
 	assert.Equal(t, "boolean", DataType(true))
 	assert.Equal(t, "number", DataType(16))
+	assert.Equal(t, "number", DataType(1.1))
+	assert.Equal(t, "number", DataType(-1))
 	assert.Equal(t, "string", DataType("hello world"))
-	assert.Equal(t, "array", DataType([]string{"hello", "world"}))
-	assert.Equal(t, "object", DataType(map[string]interface{}{"hello": "world"}))
 	assert.Equal(t, "null", DataType(nil))
 }


### PR DESCRIPTION
Adding coverage of bool slices, int16, uint16, and struct.  Adding byte
slice as string to mirror go json encoding behavior (uses base64 for
byte slices).
